### PR TITLE
Fix: WASM module not loading in article page on mobile

### DIFF
--- a/content/post/compact-compact-language-detector.md
+++ b/content/post/compact-compact-language-detector.md
@@ -126,12 +126,15 @@ To show how compact these libraries have become, all three compile into a single
 var ldModule = null;
 var ldDetectFT, ldDetectCLD3, ldDetectCLD2;
 
-LangDetect().then(function(m) {
+LangDetect({ locateFile: function(path) { return '/langdetect/' + path; } }).then(function(m) {
   ldModule = m;
   ldDetectFT = m.cwrap('detect_fasttext', 'string', ['string', 'number']);
   ldDetectCLD3 = m.cwrap('detect_cld3', 'string', ['string', 'number']);
   ldDetectCLD2 = m.cwrap('detect_cld2', 'string', ['string', 'number']);
   document.getElementById('ld-status').textContent = 'Ready. Type to detect language.';
+}).catch(function(e) {
+  document.getElementById('ld-status').textContent = 'Failed to load WASM module.';
+  console.error('WASM load error:', e);
 });
 
 var ldTimer = null;


### PR DESCRIPTION
The Emscripten-generated langdetect.js derives the WASM file path from
document.currentScript.src. When currentScript is unavailable (which can
happen on certain mobile browsers), the path falls back to a relative
resolution against the page URL — correct for /langdetect/ but 404 for
/post/compact-compact-language-detector/.

Pass an explicit locateFile function so the WASM path is always
/langdetect/langdetect.wasm regardless of page context. Also add a
.catch() handler to surface loading failures instead of silently
staying on "Loading WASM module..." forever.

https://claude.ai/code/session_018YRr5qbFrys7hv3vpve8Xu